### PR TITLE
Add dataclass helper functions: asdict and astuple

### DIFF
--- a/dataclass.py
+++ b/dataclass.py
@@ -15,6 +15,8 @@ __all__ = ['dataclass',
 
            # Helper functions.
            'fields',
+           'asdict',
+           'astuple',
            ]
 
 
@@ -500,3 +502,37 @@ def make_class(cls_name, fields, *, bases=None, repr=True, cmp=True,
 
 def fields(cls):
     return getattr(cls, _MARKER)
+
+
+def asdict(obj):
+    """Get the fields of a dataclass instance as a new dictionary mapping
+    field names to field values. Example usage::
+
+      @dataclass
+      class C:
+          x: int
+          y: int
+
+      c = C(1, 2)
+      assert asdict(c) == {'x': 1, 'y': 2}
+    """
+    if isinstance(obj, type):
+        raise ValueError("asdcit() should be called on dataclass instances, not classes")
+    return {name: getattr(obj, name) for name in fields(obj)}
+
+
+def astuple(obj):
+    """Get the fields of a dataclass instance as a new tuple of field values.
+    Example usage::
+
+      @dataclass
+      class C:
+          x: int
+          y: int
+
+    c = C(1, 2)
+    assert asdtuple(c) == (1, 2)
+    """
+    if isinstance(obj, type):
+        raise ValueError("astuple() should be called on dataclass instances, not classes")
+    return tuple(getattr(obj, name) for name in fields(obj))

--- a/tst.py
+++ b/tst.py
@@ -1,4 +1,6 @@
-from dataclass import dataclass, field, make_class, FrozenInstanceError, fields
+from dataclass import (
+    dataclass, field, make_class, FrozenInstanceError, fields, asdict, astuple
+)
 
 import inspect
 import unittest
@@ -1195,6 +1197,58 @@ class TestCase(unittest.TestCase):
             y: float
 
         self.assertIs(fields(C), fields(C(0, 0.0)))
+
+    def test_helper_asdict(self):
+        # Basic tests for asdict(), it should return a new dictionary
+        @dataclass
+        class C:
+            x: int
+            y: int
+        c = C(1, 2)
+
+        self.assertEqual(asdict(c), {'x': 1, 'y': 2})
+        self.assertEqual(asdict(c), asdict(c))
+        self.assertIsNot(asdict(c), asdict(c))
+        c.x = 42
+        self.assertEqual(asdict(c), {'x': 42, 'y': 2})
+        self.assertIs(type(asdict(c)), dict)
+
+    def test_helper_asdict_raises_on_classes(self):
+        # asdict() should raise on a class object
+        @dataclass
+        class C:
+            x: int
+            y: int
+        with self.assertRaisesRegex(ValueError, 'dataclass instance'):
+            asdict(C)
+        with self.assertRaisesRegex(ValueError, 'dataclass instance'):
+            asdict(int)
+
+    def test_helper_astuple(self):
+        # Basic tests for astuple(), it should return a new tuple
+        @dataclass
+        class C:
+            x: int
+            y: int = 0
+        c = C(1)
+
+        self.assertEqual(astuple(c), (1, 0))
+        self.assertEqual(astuple(c), astuple(c))
+        self.assertIsNot(astuple(c), astuple(c))
+        c.y = 42
+        self.assertEqual(astuple(c), (1, 42))
+        self.assertIs(type(astuple(c)), tuple)
+
+    def test_helper_astuple_raises_on_classes(self):
+        # astuple() should raise on a class object
+        @dataclass
+        class C:
+            x: int
+            y: int
+        with self.assertRaisesRegex(ValueError, 'dataclass instance'):
+            astuple(C)
+        with self.assertRaisesRegex(ValueError, 'dataclass instance'):
+            astuple(int)
 
 
 def main():


### PR DESCRIPTION
I do some small type checking, since this should only work on instances, I defer the other checks to ``fields`` (if there will be any).