### PR TITLE
Test init order

### DIFF
--- a/tst.py
+++ b/tst.py
@@ -1111,6 +1111,28 @@ class TestCase(unittest.TestCase):
         self.assertEqual(cls1, cls)
         self.assertEqual(asdict(cls1(1)), {'x': 1, 'y': 5})
 
+    def test_init_in_order(self):
+        @dataclass
+        class C:
+            a: int
+            b: int = field()
+            c: list = field(default_factory=list, init=False)
+            d: list = field(default_factory=list)
+            e: int = field(default=4, init=False)
+            f: int = 4
+
+        calls = []
+        def setattr(self, name, value):
+            calls.append((name, value))
+
+        C.__setattr__ = setattr
+        c = C(0, 1)
+        self.assertEqual(('a', 0), calls[0])
+        self.assertEqual(('b', 1), calls[1])
+        self.assertEqual(('c', []), calls[2])
+        self.assertEqual(('d', []), calls[3])
+        self.assertNotIn(('e', 4), calls)
+        self.assertEqual(('f', 4), calls[4])
 
 def main():
     unittest.main()

--- a/tst.py
+++ b/tst.py
@@ -387,6 +387,32 @@ class TestCase(unittest.TestCase):
         self.assertNotEqual(C(3), C(4, 10))
         self.assertNotEqual(C(3, 10), C(4, 10))
 
+    def test_hash_field_rules(self):
+        # Test all 6 cases of:
+        #  hash=True/False/None
+        #  cmp=True/False
+        for hash_val, cmp,   result in [
+            (True,    False, 'field'),
+            (True,    True,  'field'),
+            (False,   False, 'absent'),
+            (False,   True,  'absent'),
+            (None,    False, 'absent'),
+            (None,    True,  'field'),
+            ]:
+            with self.subTest(hash_val=hash_val, cmp=cmp):
+                @dataclass(hash=True)
+                class C:
+                    x: int = field(cmp=cmp, hash=hash_val, default=5)
+
+                if result == 'field':
+                    # __hash__ contains the field.
+                    self.assertEqual(C(5).__hash__(), hash((5,)))
+                elif result == 'absent':
+                    # The field is not present in the hash.
+                    self.assertEqual(C(5).__hash__(), hash(()))
+                else:
+                    assert False, f'unknown result {result!r}'
+
     def test_not_in_init(self):
         # If init=False, we must have a default value.
         # Otherwise, how would it get initialized?


### PR DESCRIPTION
Adding a test for that the attributes are initialized (in __init__) in the order of their declaration.