### PR TITLE
Improve asdict and astuple

### DIFF
--- a/dataclasses.py
+++ b/dataclasses.py
@@ -500,7 +500,7 @@ def fields(cls):
     return getattr(cls, _MARKER)
 
 
-def asdict(obj, *, copy_fields=True, nested=False, dict_factory=None):
+def asdict(obj, *, copy_function=copy.copy, dict_factory=dict, nested=False):
     """Get the fields of a dataclass instance as a new dictionary mapping
     field names to field values. Example usage::
 
@@ -512,7 +512,8 @@ def asdict(obj, *, copy_fields=True, nested=False, dict_factory=None):
       c = C(1, 2)
       assert asdict(c) == {'x': 1, 'y': 2}
 
-    If 'copy_fields' is True (default), use shallow copy of field values.
+    The 'copy_function' (if not None) is applied to field values, by default
+    this is shallow copy.copy from standard library.
     If given, 'dict_factory' will be used instead of built-in dict.
     If 'nested' is True, apply 'asdict' to field values that are dataclass
     instances.
@@ -523,15 +524,15 @@ def asdict(obj, *, copy_fields=True, nested=False, dict_factory=None):
     for name in fields(obj):
         value = getattr(obj, name)
         if nested and hasattr(value, _MARKER):
-            value = asdict(value, copy_fields=copy_fields,
-                           nested=nested, dict_factory=dict_factory)
-        elif copy_fields:
-            value = copy.copy(value)
+            value = asdict(value, copy_function=copy_function,
+                           dict_factory=dict_factory, nested=nested)
+        elif copy_function is not None:
+            value = copy_function(value)
         result.append((name, value))
-    return (dict_factory or dict)(result)
+    return dict_factory(result)
 
 
-def astuple(obj, *, copy_fields=True, nested=False, tuple_factory=None):
+def astuple(obj, *, copy_function=copy.copy, tuple_factory=tuple, nested=False):
     """Get the fields of a dataclass instance as a new tuple of field values.
     Example usage::
 
@@ -543,7 +544,8 @@ def astuple(obj, *, copy_fields=True, nested=False, tuple_factory=None):
     c = C(1, 2)
     assert asdtuple(c) == (1, 2)
 
-    If 'copy_fields' is True (default), use shallow copy of field values.
+    The 'copy_function' (if not None) is applied to field values, by default
+    this is shallow copy.copy from standard library.
     If given, 'tuple_factory' will be used instead of built-in tuple.
     If 'nested' is True, apply 'astuple' to field values that are dataclass
     instances.
@@ -554,9 +556,9 @@ def astuple(obj, *, copy_fields=True, nested=False, tuple_factory=None):
     for name in fields(obj):
         value = getattr(obj, name)
         if nested and hasattr(value, _MARKER):
-            value = astuple(value, copy_fields=copy_fields,
-                            nested=nested, tuple_factory=tuple_factory)
-        elif copy_fields:
-            value = copy.copy(value)
+            value = astuple(value, copy_function=copy_function,
+                            tuple_factory=tuple_factory, nested=nested)
+        elif copy_function is not None:
+            value = copy_function(value)
         result.append(value)
-    return (tuple_factory or tuple)(result)
+    return tuple_factory(result)

--- a/dataclasses.py
+++ b/dataclasses.py
@@ -500,7 +500,7 @@ def fields(cls):
     return getattr(cls, _MARKER)
 
 
-def asdict(obj, *, copy_fields=True, nested=False):
+def asdict(obj, *, copy_fields=True, nested=False, dict_factory=None):
     """Get the fields of a dataclass instance as a new dictionary mapping
     field names to field values. Example usage::
 
@@ -513,20 +513,21 @@ def asdict(obj, *, copy_fields=True, nested=False):
       assert asdict(c) == {'x': 1, 'y': 2}
 
     If 'copy_fields' is True (default), use shallow copy of field values.
+    If given, 'dict_factory' will be used instead of built-in dict.
     If 'nested' is True, apply 'asdict' to field values that are dataclass
     instances.
     """
     if isinstance(obj, type):
         raise ValueError("asdict() should be called on dataclass instances, not classes")
-    result = {}
+    result = []
     for name in fields(obj):
         value = getattr(obj, name)
         if nested and hasattr(value, _MARKER):
             value = asdict(value, copy_fields=copy_fields, nested=nested)
         elif copy_fields:
             value = copy.copy(value)
-        result[name] = value
-    return result
+        result.append((name, value))
+    return (dict_factory or dict)(result)
 
 
 def astuple(obj, *, copy_fields=True, nested=False):

--- a/dataclasses.py
+++ b/dataclasses.py
@@ -523,14 +523,15 @@ def asdict(obj, *, copy_fields=True, nested=False, dict_factory=None):
     for name in fields(obj):
         value = getattr(obj, name)
         if nested and hasattr(value, _MARKER):
-            value = asdict(value, copy_fields=copy_fields, nested=nested)
+            value = asdict(value, copy_fields=copy_fields,
+                           nested=nested, dict_factory=dict_factory)
         elif copy_fields:
             value = copy.copy(value)
         result.append((name, value))
     return (dict_factory or dict)(result)
 
 
-def astuple(obj, *, copy_fields=True, nested=False):
+def astuple(obj, *, copy_fields=True, nested=False, tuple_factory=None):
     """Get the fields of a dataclass instance as a new tuple of field values.
     Example usage::
 
@@ -543,6 +544,7 @@ def astuple(obj, *, copy_fields=True, nested=False):
     assert asdtuple(c) == (1, 2)
 
     If 'copy_fields' is True (default), use shallow copy of field values.
+    If given, 'tuple_factory' will be used instead of built-in tuple.
     If 'nested' is True, apply 'astuple' to field values that are dataclass
     instances.
     """
@@ -552,8 +554,9 @@ def astuple(obj, *, copy_fields=True, nested=False):
     for name in fields(obj):
         value = getattr(obj, name)
         if nested and hasattr(value, _MARKER):
-            value = astuple(value, copy_fields=copy_fields, nested=nested)
+            value = astuple(value, copy_fields=copy_fields,
+                            nested=nested, tuple_factory=tuple_factory)
         elif copy_fields:
             value = copy.copy(value)
         result.append(value)
-    return tuple(result)
+    return (tuple_factory or tuple)(result)

--- a/dataclasses.py
+++ b/dataclasses.py
@@ -540,6 +540,8 @@ def asdict(obj, *, dict_factory=dict):
     return _asdict_inner(obj, dict_factory)
 
 def _asdict_inner(obj, dict_factory):
+    if not hasattr(obj, _MARKER):
+        return obj
     result = []
     for name in fields(obj):
         value = getattr(obj, name)
@@ -578,6 +580,8 @@ def astuple(obj, *, tuple_factory=tuple):
     return _astuple_inner(obj, tuple_factory)
 
 def _astuple_inner(obj, tuple_factory):
+    if not hasattr(obj, _MARKER):
+        return obj
     result = []
     for name in fields(obj):
         value = getattr(obj, name)

--- a/dataclasses.py
+++ b/dataclasses.py
@@ -547,13 +547,13 @@ def _asdict_inner(obj, dict_factory):
     if isdataclass(obj):
         result = []
         for name in fields(obj):
-            value = _asdict_inner(getattr(obj, name))
+            value = _asdict_inner(getattr(obj, name), dict_factory)
             result.append((name, value))
         return dict_factory(result)
     elif isinstance(obj, (list, tuple)):
-        value = type(obj)(_asdict_inner(v, dict_factory) for v in obj)
+        return type(obj)(_asdict_inner(v, dict_factory) for v in obj)
     elif isinstance(obj, dict):
-        value = type(obj)((_asdict_inner(k, dict_factory), _asdict_inner(v, dict_factory))
+        return type(obj)((_asdict_inner(k, dict_factory), _asdict_inner(v, dict_factory))
                           for k, v in obj.items())
     else:
         return deepcopy(obj)
@@ -584,13 +584,13 @@ def _astuple_inner(obj, tuple_factory):
     if isdataclass(obj):
         result = []
         for name in fields(obj):
-            value = _astuple_inner(getattr(obj, name))
+            value = _astuple_inner(getattr(obj, name), tuple_factory)
             result.append(value)
         return tuple_factory(result)
     elif isinstance(obj, (list, tuple)):
-        value = type(obj)(_astuple_inner(v, tuple_factory) for v in obj)
+        return type(obj)(_astuple_inner(v, tuple_factory) for v in obj)
     elif isinstance(obj, dict):
-        value = type(obj)((_astuple_inner(k, tuple_factory), _astuple_inner(v, tuple_factory))
+        return type(obj)((_astuple_inner(k, tuple_factory), _astuple_inner(v, tuple_factory))
                           for k, v in obj.items())
     else:
         return deepcopy(obj)

--- a/tst.py
+++ b/tst.py
@@ -5,7 +5,7 @@ from dataclasses import (
 import inspect
 import unittest
 from typing import ClassVar, Any, List
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 
 # Just any custom exception we can catch.
 class CustomError(Exception): pass
@@ -1241,6 +1241,23 @@ class TestCase(unittest.TestCase):
         self.assertIsNot(astuple(u, nested=True), astuple(u, nested=True))
         u.id.group = 2
         self.assertEqual(astuple(u, nested=True), ('Joe', (123, 2)))
+
+    def test_helper_astuple_factory(self):
+        @dataclass
+        class C:
+            x: int
+            y: int
+        NT = namedtuple('NT', 'x y')
+        def nt(lst):
+            return NT(*lst)
+        c = C(1, 2)
+        t = astuple(c, tuple_factory=nt)
+        self.assertEqual(t, NT(1, 2))
+        self.assertIsNot(t, astuple(c, tuple_factory=nt))
+        c.x = 42
+        t = astuple(c, tuple_factory=nt)
+        self.assertEqual(t, NT(42, 2))
+        self.assertIs(type(t), NT)
 
     def test_dynamic_class_creation(self):
         cls_dict = {'__annotations__': OrderedDict(x=int, y=int),

--- a/tst.py
+++ b/tst.py
@@ -1133,10 +1133,10 @@ class TestCase(unittest.TestCase):
             y: List[int] = field(default_factory=list)
         initial = []
         c = C(1, initial)
-        d = asdict(c, copy_fields=False)
+        d = asdict(c, copy_function=None)
         self.assertIs(d['y'], initial)
         c = C(1)
-        d = asdict(c, copy_fields=False)
+        d = asdict(c, copy_function=None)
         d['y'].append(1)
         self.assertEqual(c.y, [1])
 
@@ -1219,10 +1219,10 @@ class TestCase(unittest.TestCase):
             y: List[int] = field(default_factory=list)
         initial = []
         c = C(1, initial)
-        t = astuple(c, copy_fields=False)
+        t = astuple(c, copy_function=None)
         self.assertIs(t[1], initial)
         c = C(1)
-        t = astuple(c, copy_fields=False)
+        t = astuple(c, copy_function=None)
         t[1].append(1)
         self.assertEqual(c.y, [1])
 

--- a/tst.py
+++ b/tst.py
@@ -1157,6 +1157,20 @@ class TestCase(unittest.TestCase):
         self.assertEqual(asdict(u, nested=True), {'name': 'Joe',
                                                   'id': {'token': 123, 'group': 2}})
 
+    def test_helper_asdict_factory(self):
+        @dataclass
+        class C:
+            x: int
+            y: int
+        c = C(1, 2)
+        d = asdict(c, dict_factory=OrderedDict)
+        self.assertEqual(d, OrderedDict([('x', 1), ('y', 2)]))
+        self.assertIsNot(d, asdict(c, dict_factory=OrderedDict))
+        c.x = 42
+        d = asdict(c, dict_factory=OrderedDict)
+        self.assertEqual(d, OrderedDict([('x', 42), ('y', 2)]))
+        self.assertIs(type(d), OrderedDict)
+
     def test_helper_astuple(self):
         # Basic tests for astuple(), it should return a new tuple
         @dataclass

--- a/tst.py
+++ b/tst.py
@@ -1166,6 +1166,18 @@ class TestCase(unittest.TestCase):
         self.assertEqual(asdict(gd), {'id': 0, 'users': {'first': {'name': 'Alice', 'id': 1},
                                                          'second': {'name': 'Bob', 'id': 2}}})
 
+    def test_helper_asdict_builtin_containers(self):
+        @dataclass
+        class Child:
+            d: object
+
+        @dataclass
+        class Parent:
+            child: Child
+
+        self.assertEqual(asdict(Parent(Child([1]))), {'child': {'d': [1]}})
+        self.assertEqual(asdict(Parent(Child({1: 2}))), {'child': {'d': {1: 2}}})
+
     def test_helper_asdict_factory(self):
         @dataclass
         class C:
@@ -1262,6 +1274,18 @@ class TestCase(unittest.TestCase):
         self.assertEqual(astuple(gl), (0, [('Alice', 1), ('Bob', 2)]))
         self.assertEqual(astuple(gt), (0, (('Alice', 1), ('Bob', 2))))
         self.assertEqual(astuple(gd), (0, {'first': ('Alice', 1), 'second': ('Bob', 2)}))
+
+    def test_helper_astuple_builtin_containers(self):
+        @dataclass
+        class Child:
+            d: object
+
+        @dataclass
+        class Parent:
+            child: Child
+
+        self.assertEqual(astuple(Parent(Child([1]))), (([1],),))
+        self.assertEqual(astuple(Parent(Child({1: 2}))), (({1: 2},),))
 
     def test_helper_astuple_factory(self):
         @dataclass

--- a/tst.py
+++ b/tst.py
@@ -6,6 +6,7 @@ import pickle
 import inspect
 import unittest
 from unittest.mock import Mock
+from typing import ClassVar, Any, List, Union
 from collections import deque, OrderedDict, namedtuple
 
 # Just any custom exception we can catch.

--- a/tst.py
+++ b/tst.py
@@ -6,7 +6,7 @@ import pickle
 import inspect
 import unittest
 from unittest.mock import Mock
-from typing import ClassVar, Any, List, Union
+from typing import ClassVar, Any, List, Union, Tuple, Dict
 from collections import deque, OrderedDict, namedtuple
 
 # Just any custom exception we can catch.
@@ -1100,9 +1100,9 @@ class TestCase(unittest.TestCase):
         class C:
             x: int
             y: int
-        with self.assertRaisesRegex(ValueError, 'dataclass instance'):
+        with self.assertRaisesRegex(TypeError, 'dataclass instance'):
             asdict(C)
-        with self.assertRaisesRegex(ValueError, 'dataclass instance'):
+        with self.assertRaisesRegex(TypeError, 'dataclass instance'):
             asdict(int)
 
     def test_helper_asdict_copy_values(self):
@@ -1120,20 +1120,6 @@ class TestCase(unittest.TestCase):
         d['y'].append(1)
         self.assertEqual(c.y, [])
 
-    def test_helper_asdict_no_copy(self):
-        @dataclass
-        class C:
-            x: int
-            y: List[int] = field(default_factory=list)
-        initial = []
-        c = C(1, initial)
-        d = asdict(c, copy_function=None)
-        self.assertIs(d['y'], initial)
-        c = C(1)
-        d = asdict(c, copy_function=None)
-        d['y'].append(1)
-        self.assertEqual(c.y, [1])
-
     def test_helper_asdict_nested(self):
         @dataclass
         class UserId:
@@ -1144,12 +1130,41 @@ class TestCase(unittest.TestCase):
             name: str
             id: UserId
         u = User('Joe', UserId(123, 1))
-        d = asdict(u, nested=True)
+        d = asdict(u)
         self.assertEqual(d, {'name': 'Joe', 'id': {'token': 123, 'group': 1}})
-        self.assertIsNot(asdict(u, nested=True), asdict(u, nested=True))
+        self.assertIsNot(asdict(u), asdict(u))
         u.id.group = 2
-        self.assertEqual(asdict(u, nested=True), {'name': 'Joe',
-                                                  'id': {'token': 123, 'group': 2}})
+        self.assertEqual(asdict(u), {'name': 'Joe',
+                                     'id': {'token': 123, 'group': 2}})
+
+    def test_helper_asdict_builtin_containers(self):
+        @dataclass
+        class User:
+            name: str
+            id: int
+        @dataclass
+        class GroupList:
+            id: int
+            users: List[User]
+        @dataclass
+        class GroupTuple:
+            id: int
+            users: Tuple[User, ...]
+        @dataclass
+        class GroupDict:
+            id: int
+            users: Dict[str, User]
+        a = User('Alice', 1)
+        b = User('Bob', 2)
+        gl = GroupList(0, [a, b])
+        gt = GroupTuple(0, (a, b))
+        gd = GroupDict(0, {'first': a, 'second': b})
+        self.assertEqual(asdict(gl), {'id': 0, 'users': [{'name': 'Alice', 'id': 1},
+                                                         {'name': 'Bob', 'id': 2}]})
+        self.assertEqual(asdict(gt), {'id': 0, 'users': ({'name': 'Alice', 'id': 1},
+                                                         {'name': 'Bob', 'id': 2})})
+        self.assertEqual(asdict(gd), {'id': 0, 'users': {'first': {'name': 'Alice', 'id': 1},
+                                                         'second': {'name': 'Bob', 'id': 2}}})
 
     def test_helper_asdict_factory(self):
         @dataclass
@@ -1186,12 +1201,12 @@ class TestCase(unittest.TestCase):
         class C:
             x: int
             y: int
-        with self.assertRaisesRegex(ValueError, 'dataclass instance'):
+        with self.assertRaisesRegex(TypeError, 'dataclass instance'):
             astuple(C)
-        with self.assertRaisesRegex(ValueError, 'dataclass instance'):
+        with self.assertRaisesRegex(TypeError, 'dataclass instance'):
             astuple(int)
 
-    def test_helper_tuple_copy_values(self):
+    def test_helper_astuple_copy_values(self):
         @dataclass
         class C:
             x: int
@@ -1206,20 +1221,6 @@ class TestCase(unittest.TestCase):
         t[1].append(1)
         self.assertEqual(c.y, [])
 
-    def test_helper_astuple_no_copy(self):
-        @dataclass
-        class C:
-            x: int
-            y: List[int] = field(default_factory=list)
-        initial = []
-        c = C(1, initial)
-        t = astuple(c, copy_function=None)
-        self.assertIs(t[1], initial)
-        c = C(1)
-        t = astuple(c, copy_function=None)
-        t[1].append(1)
-        self.assertEqual(c.y, [1])
-
     def test_helper_astuple_nested(self):
         @dataclass
         class UserId:
@@ -1230,11 +1231,37 @@ class TestCase(unittest.TestCase):
             name: str
             id: UserId
         u = User('Joe', UserId(123, 1))
-        t = astuple(u, nested=True)
+        t = astuple(u)
         self.assertEqual(t, ('Joe', (123, 1)))
-        self.assertIsNot(astuple(u, nested=True), astuple(u, nested=True))
+        self.assertIsNot(astuple(u), astuple(u))
         u.id.group = 2
-        self.assertEqual(astuple(u, nested=True), ('Joe', (123, 2)))
+        self.assertEqual(astuple(u), ('Joe', (123, 2)))
+
+    def test_helper_astuple_builtin_containers(self):
+        @dataclass
+        class User:
+            name: str
+            id: int
+        @dataclass
+        class GroupList:
+            id: int
+            users: List[User]
+        @dataclass
+        class GroupTuple:
+            id: int
+            users: Tuple[User, ...]
+        @dataclass
+        class GroupDict:
+            id: int
+            users: Dict[str, User]
+        a = User('Alice', 1)
+        b = User('Bob', 2)
+        gl = GroupList(0, [a, b])
+        gt = GroupTuple(0, (a, b))
+        gd = GroupDict(0, {'first': a, 'second': b})
+        self.assertEqual(astuple(gl), (0, [('Alice', 1), ('Bob', 2)]))
+        self.assertEqual(astuple(gt), (0, (('Alice', 1), ('Bob', 2))))
+        self.assertEqual(astuple(gd), (0, {'first': ('Alice', 1), 'second': ('Bob', 2)}))
 
     def test_helper_astuple_factory(self):
         @dataclass


### PR DESCRIPTION
This PR adds two keyword arguments ``copy_fields`` and ``nested`` to ``asdict()`` and ``astuple()``. I think the first one should be on by default, so that simple mutable fields (like lists) will be copied by ``asdict()`` and ``astuple()``.

As well, as discussed in https://github.com/ericvsmith/dataclasses/pull/26, this adds ``dict_factory`` keyword argument, so that a user can use ``OrderedDict`` or other custom mapping.