### PR TITLE
Add test for pickling dataclasses

### DIFF
--- a/tst.py
+++ b/tst.py
@@ -2,9 +2,10 @@ from dataclasses import (
     dataclass, field, FrozenInstanceError, fields, asdict, astuple
 )
 
+import pickle
 import inspect
 import unittest
-from typing import ClassVar, Any
+from typing import ClassVar, Any, List
 from collections import OrderedDict
 
 # Just any custom exception we can catch.
@@ -1231,6 +1232,35 @@ class TestCase(unittest.TestCase):
                 return cls(value_in_file)
 
         self.assertEqual(C.from_file('filename').x, 20)
+
+    def test_dataclassses_pickleadble(self):
+        global P, Q, R
+        @dataclass
+        class P:
+            x: int
+            y: int = 0
+        @dataclass
+        class Q:
+            x: int
+            y: int = field(default=0, init=False)
+        @dataclass
+        class R:
+            x: int
+            y: List[int] = field(default_factory=list)
+        q = Q(1)
+        q.y = 2
+        samples = [P(1), P(1, 2), Q(1), q, R(1), R(1, [2, 3, 4])]
+        for sample in samples:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                new_sample = pickle.loads(pickle.dumps(sample, proto))
+                self.assertEqual(sample.x, new_sample.x)
+                self.assertEqual(sample.y, new_sample.y)
+                self.assertIsNot(sample, new_sample)
+                new_sample.x = 42
+                another_new_sample = pickle.loads(pickle.dumps(new_sample, proto))
+                self.assertEqual(new_sample.x, another_new_sample.x)
+                self.assertEqual(sample.y, another_new_sample.y)
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
It looks like dataclasses are already well pickleable, this PR adds corresponding test.