### PR TITLE
Syntax highlight Python code in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Installation
 Example Usage
 -------------
 
-.. code-block::
+.. code-block:: python
 
   from dataclasses import dataclass, field
 


### PR DESCRIPTION
This makes the example code render much better on GitHub

[Rendered](https://github.com/johnthagen/dataclasses/blob/b514d54a01cba58bbb0168277100279eabeb550a/README.rst#example-usage)