### PR TITLE
Include the readme as a long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 from setuptools import setup
 
+with open('README.rst') as readme:
+    README = readme.read()
+
 setup(
     name='dataclasses',
     version='0.5+',
     description='An implementation of PEP 557: Data Classes',
+    long_description=README,
     url='https://github.com/ericvsmith/dataclasses',
     author='Eric V. Smith',
     author_email='eric@python.org',


### PR DESCRIPTION
Currently, the https://pypi.org/p/dataclasses page is worryingly empty. Include a long description.