### PR TITLE
Make pypi shield link to project's pypi page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
 .. image:: https://img.shields.io/pypi/v/dataclasses.svg
+   :target: https://pypi.org/project/dataclasses/
 
 
 This is an implementation of PEP 557, Data Classes.  It is a backport


### PR DESCRIPTION
right now it links to the image itself. this seems more valuable