### PR TITLE
Added python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.6',
     ],
-    py_modules=['dataclasses']
+    py_modules=['dataclasses'],
+    python_requires='== 3.6.*'
 )


### PR DESCRIPTION
This prevents any further releases from being mistakenly installed on Python 3.5 (which does not support the syntax involved) or 3.7 (which has dataclasses in the standard library). The damage is already done though and the fix will only apply to future releases.