### PR TITLE
Use setuptools declarative configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[metadata]
+name = dataclasses
+version = 0.7
+description = A backport of the dataclasses module for Python 3.6
+long_description = file: README.rst
+url = https://github.com/ericvsmith/dataclasses
+author = Eric V. Smith
+author_email = eric@python.org
+license = Apache
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Topic :: Software Development :: Libraries :: Python Modules
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.6
+
+[options]
+py_modules =
+    dataclasses
+python_requires = >=3.6, <3.7

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,3 @@
 from setuptools import setup
 
-with open("README.rst") as readme:
-    README = readme.read()
-
-setup(
-    name="dataclasses",
-    version="0.7",
-    description="A backport of the dataclasses module for Python 3.6",
-    long_description=README,
-    url="https://github.com/ericvsmith/dataclasses",
-    author="Eric V. Smith",
-    author_email="eric@python.org",
-    license="Apache",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.6",
-    ],
-    py_modules=["dataclasses"],
-    python_requires=">=3.6, <3.7",
-)
+setup()


### PR DESCRIPTION
Avoids mixing logic and configuration. The configuration is now easily
parsable by 3rd party tools.

https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files